### PR TITLE
Feature/ch112862/add endpoint for searching private identifiers

### DIFF
--- a/integration/app.py
+++ b/integration/app.py
@@ -79,9 +79,9 @@ def run_app(cls):
             return jsonify({"error": traceback.format_exc()}), 500
 
     @app.route("/data/search", methods=["POST"])
-    def retrieve_private_identifiers() -> Tuple[Union[List[Dict], Dict], int]:
+    def search_private_identifiers_values() -> Tuple[Union[List[Dict], Dict], int]:
         if request.json and "identifiers" in request.json:
-            membership_data = membership_service.get_private_identifier_value_list(
+            membership_data = membership_service.search_private_identifiers_values(
                 uuids=request.json["identifiers"]
             )
             if len(membership_data["data"]) > 0:

--- a/integration/app.py
+++ b/integration/app.py
@@ -1,15 +1,15 @@
 import traceback
 from typing import Dict, List, Tuple, Union
 
-from flask import Flask, abort, jsonify, request, Response
+from flask import Flask, jsonify, request
 
 from integration.rest_service.api_client import BaseAPIClient, CodeRequestResponse
 from integration.rest_service.exceptions import (
-    InvalidMembership,
-    UnusableMembership,
-    GenericSatelliteException,
     BadRequest,
+    GenericSatelliteException,
+    InvalidMembership,
     NotFound,
+    UnusableMembership,
 )
 from integration.rest_service.service import MembershipService
 

--- a/integration/app.py
+++ b/integration/app.py
@@ -1,10 +1,16 @@
 import traceback
-from typing import Dict, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
-from flask import Flask, abort, jsonify, request
+from flask import Flask, abort, jsonify, request, Response
 
 from integration.rest_service.api_client import BaseAPIClient, CodeRequestResponse
-from integration.rest_service.exceptions import InvalidMembership, UnusableMembership
+from integration.rest_service.exceptions import (
+    InvalidMembership,
+    UnusableMembership,
+    GenericSatelliteException,
+    BadRequest,
+    NotFound,
+)
 from integration.rest_service.service import MembershipService
 
 
@@ -72,6 +78,17 @@ def run_app(cls):
         except Exception:
             return jsonify({"error": traceback.format_exc()}), 500
 
+    @app.route("/data/search", methods=["POST"])
+    def retrieve_private_identifiers() -> Tuple[Union[List[Dict], Dict], int]:
+        if request.json and "identifiers" in request.json:
+            membership_data = membership_service.get_private_identifier_value_list(
+                uuids=request.json["identifiers"]
+            )
+            if len(membership_data) > 0:
+                return membership_data, 200
+            raise NotFound
+        raise BadRequest
+
     @app.route("/data/", methods=["POST"])
     def create_private_identifier() -> Tuple[Dict, int]:
         value = request.json.get("value")
@@ -92,5 +109,10 @@ def run_app(cls):
         if membership_service.delete_private_identifier(uuid):
             return {}, 200
         return jsonify({"error": "NOT_FOUND"}), 404
+
+    @app.errorhandler(GenericSatelliteException)
+    def handle_exception(e: GenericSatelliteException) -> Tuple[Dict, int]:
+        """Return serialized JSON for GenericSatelliteException errors"""
+        return jsonify({"error": e.error_code}), e.status_code
 
     return app

--- a/integration/app.py
+++ b/integration/app.py
@@ -84,7 +84,7 @@ def run_app(cls):
             membership_data = membership_service.get_private_identifier_value_list(
                 uuids=request.json["identifiers"]
             )
-            if len(membership_data) > 0:
+            if len(membership_data["data"]) > 0:
                 return membership_data, 200
             raise NotFound
         raise BadRequest

--- a/integration/rest_service/api_client.py
+++ b/integration/rest_service/api_client.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 
 class CodeRequestResponse(TypedDict):
@@ -6,12 +6,13 @@ class CodeRequestResponse(TypedDict):
     error: Optional[str]
 
 
-class PrivateIdentifierData(TypedDict):
+class PrivateIdentifier(TypedDict):
     identifier: str
-
-
-class PrivateIdentifierValue(TypedDict):
     value: str
+
+
+class PrivateIdentifierList(TypedDict):
+    data: List[PrivateIdentifier]
 
 
 class BaseAPIClient:
@@ -27,12 +28,15 @@ class BaseAPIClient:
     def request_verification_code(self, user_data: Dict) -> CodeRequestResponse:
         raise NotImplementedError
 
-    def create_private_identifier(self, value: str) -> PrivateIdentifierData:
+    def get_private_identifier_value_list(
+        self, uuids: List[str]
+    ) -> PrivateIdentifierList:
+        return NotImplementedError
+
+    def create_private_identifier(self, value: str) -> PrivateIdentifier:
         raise NotImplementedError
 
-    def get_private_identifier_value(
-        self, uuid: str
-    ) -> Optional[PrivateIdentifierValue]:
+    def get_private_identifier_value(self, uuid: str) -> Optional[PrivateIdentifier]:
         raise NotImplementedError
 
     def delete_private_identifier(self, uuid: str) -> bool:

--- a/integration/rest_service/api_client.py
+++ b/integration/rest_service/api_client.py
@@ -28,7 +28,7 @@ class BaseAPIClient:
     def request_verification_code(self, user_data: Dict) -> CodeRequestResponse:
         raise NotImplementedError
 
-    def get_private_identifier_value_list(
+    def search_private_identifiers_values(
         self, uuids: List[str]
     ) -> PrivateIdentifierList:
         return NotImplementedError

--- a/integration/rest_service/exceptions.py
+++ b/integration/rest_service/exceptions.py
@@ -1,9 +1,6 @@
 class GenericSatelliteException(Exception):
     status_code = 500
-
-    def __init__(self, *args: object):
-        super().__init__(args)
-        self.error_code = None
+    error_code = ""
 
 
 class ServiceUnavailableException(Exception):

--- a/integration/rest_service/exceptions.py
+++ b/integration/rest_service/exceptions.py
@@ -1,3 +1,11 @@
+class GenericSatelliteException(Exception):
+    status_code = 500
+
+    def __init__(self, *args: object):
+        super().__init__(args)
+        self.error_code = None
+
+
 class ServiceUnavailableException(Exception):
     status_code = 503
 
@@ -14,3 +22,17 @@ class UnusableMembership(Exception):
 class InvalidMembership(Exception):
     # Not existent membership
     pass
+
+
+class BadRequest(GenericSatelliteException):
+    status_code = 400
+    error_code = "BAD_REQUEST"
+
+
+class SearchFilterLimitReached(BadRequest):
+    error_code = "SEARCH_FILTER_LIMIT_REACHED"
+
+
+class NotFound(GenericSatelliteException):
+    status_code = 404
+    error_code = "NOT_FOUND"

--- a/integration/rest_service/service.py
+++ b/integration/rest_service/service.py
@@ -1,10 +1,10 @@
-from typing import Dict, Optional
+from typing import List, Dict, Optional
 
 from integration.rest_service.api_client import (
     BaseAPIClient,
     CodeRequestResponse,
-    PrivateIdentifierData,
-    PrivateIdentifierValue,
+    PrivateIdentifier,
+    PrivateIdentifierList,
 )
 
 
@@ -24,12 +24,15 @@ class MembershipService:
     def request_verification_code(self, user_data: Dict) -> CodeRequestResponse:
         return self.api_client.request_verification_code(user_data)
 
-    def create_private_identifier(self, value: str) -> PrivateIdentifierData:
+    def get_private_identifier_value_list(
+        self, uuids: List[str]
+    ) -> PrivateIdentifierList:
+        return self.api_client.get_private_identifier_value_list(uuids)
+
+    def create_private_identifier(self, value: str) -> PrivateIdentifier:
         return self.api_client.create_private_identifier(value)
 
-    def get_private_identifier_value(
-        self, uuid: str
-    ) -> Optional[PrivateIdentifierValue]:
+    def get_private_identifier_value(self, uuid: str) -> Optional[PrivateIdentifier]:
         return self.api_client.get_private_identifier_value(uuid)
 
     def delete_private_identifier(self, uuid: str) -> bool:

--- a/integration/rest_service/service.py
+++ b/integration/rest_service/service.py
@@ -24,10 +24,10 @@ class MembershipService:
     def request_verification_code(self, user_data: Dict) -> CodeRequestResponse:
         return self.api_client.request_verification_code(user_data)
 
-    def get_private_identifier_value_list(
+    def search_private_identifiers_values(
         self, uuids: List[str]
     ) -> PrivateIdentifierList:
-        return self.api_client.get_private_identifier_value_list(uuids)
+        return self.api_client.search_private_identifiers_values(uuids)
 
     def create_private_identifier(self, value: str) -> PrivateIdentifier:
         return self.api_client.create_private_identifier(value)

--- a/integration/rest_service/service.py
+++ b/integration/rest_service/service.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 from integration.rest_service.api_client import (
     BaseAPIClient,


### PR DESCRIPTION
Add an endpoint that allows searching by UUIDs on the local database. Method defined as POST request due to existing query string limit for GET request. In this endpoint, the list of UUIDs to retrieve should be shared in the payload under the JSON key `identifiers` 

- add an endpoint for searching private identifiers. `/data/search` (app.py)
- Define a new dataclass for the result list called PrivateIdentifierList (api_client.py)
- Merge PrivateIdentifierData and PrivateIdentifierValue dataclasses to PrivateIdentifier (api_client.py). The same object will be used to return responses for GET/POST related to local DB instances
- Generate custom exceptions (exceptions.py) and define a handler for these exceptions (app.py)

After merge this code a new release will be generated