### PR TITLE
Feature/ch120547/let raise unhandled exceptions for satellite

### DIFF
--- a/integration/app.py
+++ b/integration/app.py
@@ -5,7 +5,7 @@ from flask import Flask, jsonify, request
 from integration.rest_service.api_client import BaseAPIClient, CodeRequestResponse
 from integration.rest_service.exceptions import (
     BadRequest,
-    GenericSatelliteException,
+    HandledSatelliteException,
     InvalidMembership,
     NotFound,
     UnusableMembership,
@@ -103,9 +103,9 @@ def run_app(cls):
             return {}, 200
         return jsonify({"error": "NOT_FOUND"}), 404
 
-    @app.errorhandler(GenericSatelliteException)
-    def handle_exception(e: GenericSatelliteException) -> Tuple[Dict, int]:
-        """Return serialized JSON for GenericSatelliteException errors"""
+    @app.errorhandler(HandledSatelliteException)
+    def handle_exception(e: HandledSatelliteException) -> Tuple[Dict, int]:
+        """Return serialized JSON for HandledSatelliteException errors"""
         return jsonify({"error": e.error_code}), e.status_code
 
     return app

--- a/integration/app.py
+++ b/integration/app.py
@@ -6,9 +6,8 @@ from integration.rest_service.api_client import BaseAPIClient, CodeRequestRespon
 from integration.rest_service.exceptions import (
     BadRequest,
     HandledSatelliteException,
-    InvalidMembership,
+    ServiceUnavailableException,
     NotFound,
-    UnusableMembership,
 )
 from integration.rest_service.service import MembershipService
 
@@ -51,7 +50,7 @@ def run_app(cls):
     def external_health() -> Tuple[Dict, int]:
         if membership_service.external_service_is_healthy():
             return {}, 200
-        return {}, 503
+        raise ServiceUnavailableException
 
     @app.route("/request_code", methods=["POST"])
     def code_request() -> Tuple[Union[Dict, CodeRequestResponse], int]:

--- a/integration/app.py
+++ b/integration/app.py
@@ -22,32 +22,24 @@ def run_app(cls):
 
     @app.route("/authenticate", methods=["POST"])
     def authenticate() -> Tuple[Dict, int]:
-        try:
-            membership_data = membership_service.get_membership_identifier(request.json)
-            if not bool(membership_data):
-                return {}, 403
+        membership_data = membership_service.get_membership_identifier(request.json)
+        if not bool(membership_data):
+            return {}, 403
 
-            return membership_data, 200
-        except InvalidMembership:
-            return jsonify({"error": "INVALID_MEMBERSHIP"}), 200
-        except UnusableMembership:
-            return jsonify({"error": "UNUSABLE_MEMBERSHIP"}), 200
+        return membership_data, 200
 
     @app.route("/validate", methods=["POST"])
     def validate() -> Tuple[Dict, int]:
-        try:
-            return (
-                jsonify(
-                    {
-                        "is_active": membership_service.is_active(
-                            request.json.get("identifier")
-                        )
-                    }
-                ),
-                200,
-            )
-        except UnusableMembership:
-            return jsonify({"error": "UNUSABLE_ACCOUNT"}), 200
+        return (
+            jsonify(
+                {
+                    "is_active": membership_service.is_active(
+                        request.json.get("identifier")
+                    )
+                }
+            ),
+            200,
+        )
 
     # Own's API's health
     @app.route("/healthz", methods=["GET"])
@@ -63,13 +55,8 @@ def run_app(cls):
 
     @app.route("/request_code", methods=["POST"])
     def code_request() -> Tuple[Union[Dict, CodeRequestResponse], int]:
-        try:
-            membership_data = membership_service.request_verification_code(request.json)
-            return membership_data, 200
-        except InvalidMembership:
-            return jsonify({"error": "INVALID_MEMBERSHIP"}), 200
-        except UnusableMembership:
-            return jsonify({"error": "UNUSABLE_MEMBERSHIP"}), 200
+        membership_data = membership_service.request_verification_code(request.json)
+        return membership_data, 200
 
     @app.route("/data/search", methods=["POST"])
     def search_private_identifiers_values() -> Tuple[Union[List[Dict], Dict], int]:

--- a/integration/app.py
+++ b/integration/app.py
@@ -1,4 +1,3 @@
-import traceback
 from typing import Dict, List, Tuple, Union
 
 from flask import Flask, jsonify, request
@@ -33,8 +32,6 @@ def run_app(cls):
             return jsonify({"error": "INVALID_MEMBERSHIP"}), 200
         except UnusableMembership:
             return jsonify({"error": "UNUSABLE_MEMBERSHIP"}), 200
-        except Exception:
-            return jsonify({"error": traceback.format_exc()}), 500
 
     @app.route("/validate", methods=["POST"])
     def validate() -> Tuple[Dict, int]:
@@ -51,8 +48,6 @@ def run_app(cls):
             )
         except UnusableMembership:
             return jsonify({"error": "UNUSABLE_ACCOUNT"}), 200
-        except Exception:
-            return jsonify({"error": traceback.format_exc()}), 500
 
     # Own's API's health
     @app.route("/healthz", methods=["GET"])
@@ -75,8 +70,6 @@ def run_app(cls):
             return jsonify({"error": "INVALID_MEMBERSHIP"}), 200
         except UnusableMembership:
             return jsonify({"error": "UNUSABLE_MEMBERSHIP"}), 200
-        except Exception:
-            return jsonify({"error": traceback.format_exc()}), 500
 
     @app.route("/data/search", methods=["POST"])
     def search_private_identifiers_values() -> Tuple[Union[List[Dict], Dict], int]:

--- a/integration/app.py
+++ b/integration/app.py
@@ -82,13 +82,13 @@ def run_app(cls):
         membership_data = membership_service.get_private_identifier_value(uuid)
         if membership_data:
             return membership_data, 200
-        return jsonify({"error": "NOT_FOUND"}), 404
+        raise NotFound
 
     @app.route("/data/<uuid>", methods=["DELETE"])
     def delete_private_identifier(uuid: str) -> Tuple[Dict, int]:
         if membership_service.delete_private_identifier(uuid):
             return {}, 200
-        return jsonify({"error": "NOT_FOUND"}), 404
+        raise NotFound
 
     @app.errorhandler(HandledSatelliteException)
     def handle_exception(e: HandledSatelliteException) -> Tuple[Dict, int]:

--- a/integration/rest_service/exceptions.py
+++ b/integration/rest_service/exceptions.py
@@ -1,34 +1,65 @@
 class ServiceUnavailableException(Exception):
+    """
+    Handle service unavailable or any other exception. Unhandled exception.
+    """
+
     pass
 
 
 class ImproperlyConfigured(Exception):
+    """
+    Handle error for improperly configuration from requester. Unhandled exception.
+    """
+
     pass
 
 
 class HandledSatelliteException(Exception):
+    """
+    Base class for Handled exceptions, these exceptions
+    will response with the defined status code and the serialized error code.
+    """
+
     status_code = 400
     error_code = ""
 
 
 class UnusableMembership(HandledSatelliteException):
-    # Valid membership but deleted, expired, canceled, etc
+    """
+    Handle valid membership but deleted, expired, canceled, etc.
+    """
+
     error_code = "UNUSABLE_MEMBERSHIP"
 
 
 class InvalidMembership(HandledSatelliteException):
-    # Not existent membership
+    """
+    Handle not existent membership.
+    """
+
     error_code = "INVALID_MEMBERSHIP"
 
 
 class BadRequest(HandledSatelliteException):
+    """
+    Handle Bad request.
+    """
+
     error_code = "BAD_REQUEST"
 
 
 class SearchFilterLimitReached(BadRequest):
+    """
+    Handle max allowed limit for search filter.
+    """
+
     error_code = "SEARCH_FILTER_LIMIT_REACHED"
 
 
 class NotFound(HandledSatelliteException):
+    """
+    Handle not found error.
+    """
+
     status_code = 404
     error_code = "NOT_FOUND"

--- a/integration/rest_service/exceptions.py
+++ b/integration/rest_service/exceptions.py
@@ -1,28 +1,27 @@
-class GenericSatelliteException(Exception):
-    status_code = 500
-    error_code = ""
-
-
 class ServiceUnavailableException(Exception):
-    status_code = 503
+    pass
 
 
 class ImproperlyConfigured(Exception):
     pass
 
 
-class UnusableMembership(Exception):
-    # Valid membership but deleted, expired, canceled, etc
-    pass
-
-
-class InvalidMembership(Exception):
-    # Not existent membership
-    pass
-
-
-class BadRequest(GenericSatelliteException):
+class HandledSatelliteException(Exception):
     status_code = 400
+    error_code = ""
+
+
+class UnusableMembership(HandledSatelliteException):
+    # Valid membership but deleted, expired, canceled, etc
+    error_code = "UNUSABLE_MEMBERSHIP"
+
+
+class InvalidMembership(HandledSatelliteException):
+    # Not existent membership
+    error_code = "INVALID_MEMBERSHIP"
+
+
+class BadRequest(HandledSatelliteException):
     error_code = "BAD_REQUEST"
 
 
@@ -30,6 +29,6 @@ class SearchFilterLimitReached(BadRequest):
     error_code = "SEARCH_FILTER_LIMIT_REACHED"
 
 
-class NotFound(GenericSatelliteException):
+class NotFound(HandledSatelliteException):
     status_code = 404
     error_code = "NOT_FOUND"


### PR DESCRIPTION
 Improve error handling for errors
- Unhandled exceptions `ServiceUnavailableException`, `ImproperlyConfigured` now aren't caught by the code. It will raise an error 500 as always but now will allow us to catch these errors on Sentry (We want to be notified of these and the rest of unexpected errors)
- Add a proper name to `GenericSatelliteException` renaming it to `HandledSatelliteException`, since these errors are handled by the custom error handler it makes more sense to avoid a misunderstanding 
- `UnusableMembership` and `InvalidMembership` now inherit from `HandledSatelliteException`, this allows us to delete the custom responses for these exceptions defined in the endpoints:  /authenticate, /validate and /code_request. With the custom error handler once raised these errors the proper message and status will be returned. 
